### PR TITLE
Improve fortune-llm setup and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@ This repository contains a simple Tetris game implemented with HTML, CSS and Jav
 ## Development
 Open `index.html` in a web browser to start playing.
 
+### Using the fortune teller demo
+
+The `fortune-llm` directory contains a small demo that calls the OpenAI Chat
+Completion API. To use it you must provide your own API key.
+
+1. Edit `fortune-llm/script.js` and set the `apiKey` constant to your key **or**
+   expose the key at runtime by assigning it to `window.OPENAI_API_KEY` before the
+   script is loaded.
+2. Open `fortune-llm/index.html` in a browser.
+
+If the key is missing the page will display a friendly message instead of calling
+the API.
+
 ## Deployment
 GitHub Actions deploys the content of this repository to the `gh-pages` branch so it can be served with GitHub Pages.
 

--- a/fortune-llm/script.js
+++ b/fortune-llm/script.js
@@ -1,23 +1,35 @@
-const apiKey = '';
+const apiKey = window.OPENAI_API_KEY || '';
+
+const resultEl = document.getElementById('result');
 
 document.getElementById('fortuneForm').addEventListener('submit', async (e) => {
     e.preventDefault();
+
+    if (!apiKey) {
+        resultEl.textContent = 'APIキーが設定されていません。script.jsを編集するか OPENAI_API_KEY 環境変数を設定してください。';
+        return;
+    }
+
     const name = document.getElementById('name').value;
     const prompt = `${name}さんの今日の運勢を教えてください。`;
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${apiKey}`
-        },
-        body: JSON.stringify({
-            model: 'gpt-4o-mini',
-            messages: [{ role: 'user', content: prompt }]
-        })
-    });
+    try {
+        const response = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`
+            },
+            body: JSON.stringify({
+                model: 'gpt-4o-mini',
+                messages: [{ role: 'user', content: prompt }]
+            })
+        });
 
-    const data = await response.json();
-    const result = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content;
-    document.getElementById('result').textContent = result || 'エラーが発生しました';
+        const data = await response.json();
+        const result = data.choices?.[0]?.message?.content;
+        resultEl.textContent = result || 'エラーが発生しました';
+    } catch (err) {
+        resultEl.textContent = 'リクエストに失敗しました。';
+    }
 });


### PR DESCRIPTION
## Summary
- document how to configure the fortune-teller demo
- check for missing API key in `script.js`
- handle fetch errors with try/catch
- simplify reading LLM response with optional chaining

## Testing
- `pytest -q` *(fails: command not found)*
- `npm -v`
