### PR TITLE
Fix conflicting gh-pages workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy Fortune LLM to GitHub Pages
 
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- serve the repository root via the default GitHub Pages workflow
- trigger the `fortune-llm` deploy job only on manual workflow dispatches

## Testing
- `pre-commit` *(fails: command not found)*
