### PR TITLE
Improve fortune-llm usage docs and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,14 @@ Pull requests automatically build a preview of the site using a separate `gh-pag
 ## Fortune LLM
 The `fortune-llm` directory contains a small web app that calls the OpenAI API to generate a daily fortune. To try it locally, put your API key in `fortune-llm/script.js` and open `fortune-llm/index.html` in your browser.
 
+### Setting your API key
+
+Edit `fortune-llm/script.js` and replace the empty string assigned to `apiKey` with your own OpenAI API key:
+
+```javascript
+const apiKey = 'sk-...';
+```
+
+Alternatively you can expose the key at runtime by assigning it to `window.OPENAI_API_KEY` before the script is loaded.
+
 Changes pushed to `main` are deployed by the workflow in `.github/workflows/deploy.yml`, publishing this folder to GitHub Pages together with the rest of the site.

--- a/fortune-llm/script.js
+++ b/fortune-llm/script.js
@@ -1,35 +1,40 @@
 const apiKey = window.OPENAI_API_KEY || '';
 
 const resultEl = document.getElementById('result');
+const formEl = document.getElementById('fortuneForm');
 
-document.getElementById('fortuneForm').addEventListener('submit', async (e) => {
-    e.preventDefault();
+if (!apiKey) {
+    resultEl.textContent = 'API キーを設定してください';
+} else {
+    formEl.addEventListener('submit', async (e) => {
+        e.preventDefault();
 
-    if (!apiKey) {
-        resultEl.textContent = 'APIキーが設定されていません。script.jsを編集するか OPENAI_API_KEY 環境変数を設定してください。';
-        return;
-    }
+        const name = document.getElementById('name').value;
+        const prompt = `${name}さんの今日の運勢を教えてください。`;
 
-    const name = document.getElementById('name').value;
-    const prompt = `${name}さんの今日の運勢を教えてください。`;
+        try {
+            const response = await fetch('https://api.openai.com/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${apiKey}`
+                },
+                body: JSON.stringify({
+                    model: 'gpt-4o-mini',
+                    messages: [{ role: 'user', content: prompt }]
+                })
+            });
 
-    try {
-        const response = await fetch('https://api.openai.com/v1/chat/completions', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${apiKey}`
-            },
-            body: JSON.stringify({
-                model: 'gpt-4o-mini',
-                messages: [{ role: 'user', content: prompt }]
-            })
-        });
+            if (!response.ok) {
+                resultEl.textContent = `API リクエストに失敗しました: ${response.status} ${response.statusText}`;
+                return;
+            }
 
-        const data = await response.json();
-        const result = data.choices?.[0]?.message?.content;
-        resultEl.textContent = result || 'エラーが発生しました';
-    } catch (err) {
-        resultEl.textContent = 'リクエストに失敗しました。';
-    }
-});
+            const data = await response.json();
+            const result = data.choices?.[0]?.message?.content;
+            resultEl.textContent = result || 'エラーが発生しました';
+        } catch (err) {
+            resultEl.textContent = 'リクエストに失敗しました。';
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- document how to put your OpenAI API key in `script.js`
- warn if `apiKey` is empty and stop the script
- show fetch errors when the request fails

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: command not found)*