### PR TITLE
Add browser input for OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Open `index.html` in a web browser to start playing.
 The `fortune-llm` directory contains a small demo that calls the OpenAI Chat
 Completion API. To use it you must provide your own API key.
 
-1. Edit `fortune-llm/script.js` and set the `apiKey` constant to your key **or**
-   expose the key at runtime by assigning it to `window.OPENAI_API_KEY` before the
-   script is loaded.
-2. Open `fortune-llm/index.html` in a browser.
+1. Open `fortune-llm/index.html` in a browser.
+2. ページ上部のフィールドに OpenAI API キーを入力します。
+   キーはブラウザの `localStorage` に保存され、次回以降自動的に読み込まれます。
+3. 必要に応じて、スクリプト読み込み前に `window.OPENAI_API_KEY` を設定してキーを
+   渡すこともできます。
 
 If the key is missing the page will display a friendly message instead of calling
 the API.
@@ -24,16 +25,10 @@ GitHub Actions deploys the content of this repository to the `gh-pages` branch s
 Pull requests automatically build a preview of the site using a separate `gh-pages-pr` branch. Each PR is deployed to a `pr-<number>` directory under that branch.
 
 ## Fortune LLM
-The `fortune-llm` directory contains a small web app that calls the OpenAI API to generate a daily fortune. To try it locally, put your API key in `fortune-llm/script.js` and open `fortune-llm/index.html` in your browser.
+The `fortune-llm` directory contains a small web app that calls the OpenAI API to generate a daily fortune. Open `fortune-llm/index.html` in your browser and enter your API key when prompted.
 
 ### Setting your API key
 
-Edit `fortune-llm/script.js` and replace the empty string assigned to `apiKey` with your own OpenAI API key:
-
-```javascript
-const apiKey = 'sk-...';
-```
-
-Alternatively you can expose the key at runtime by assigning it to `window.OPENAI_API_KEY` before the script is loaded.
+Enter your OpenAI API key in the input field at the top of the page. The key is stored in `localStorage` so you don't have to re-enter it each time. Alternatively you can expose the key at runtime by assigning it to `window.OPENAI_API_KEY` before the script is loaded.
 
 Changes pushed to `main` are deployed by the workflow in `.github/workflows/deploy.yml`, publishing this folder to GitHub Pages together with the rest of the site.

--- a/fortune-llm/index.html
+++ b/fortune-llm/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <form id="fortuneForm">
+        <input type="password" id="apiKey" placeholder="OpenAI APIキー" required>
         <input type="text" id="name" placeholder="名前を入力" required>
         <button type="submit">占う</button>
     </form>

--- a/fortune-llm/script.js
+++ b/fortune-llm/script.js
@@ -1,40 +1,47 @@
-const apiKey = window.OPENAI_API_KEY || '';
-
 const resultEl = document.getElementById('result');
 const formEl = document.getElementById('fortuneForm');
+const apiKeyInput = document.getElementById('apiKey');
 
-if (!apiKey) {
-    resultEl.textContent = 'API キーを設定してください';
-} else {
-    formEl.addEventListener('submit', async (e) => {
-        e.preventDefault();
-
-        const name = document.getElementById('name').value;
-        const prompt = `${name}さんの今日の運勢を教えてください。`;
-
-        try {
-            const response = await fetch('https://api.openai.com/v1/chat/completions', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${apiKey}`
-                },
-                body: JSON.stringify({
-                    model: 'gpt-4o-mini',
-                    messages: [{ role: 'user', content: prompt }]
-                })
-            });
-
-            if (!response.ok) {
-                resultEl.textContent = `API リクエストに失敗しました: ${response.status} ${response.statusText}`;
-                return;
-            }
-
-            const data = await response.json();
-            const result = data.choices?.[0]?.message?.content;
-            resultEl.textContent = result || 'エラーが発生しました';
-        } catch (err) {
-            resultEl.textContent = 'リクエストに失敗しました。';
-        }
-    });
+const storedKey = localStorage.getItem('OPENAI_API_KEY');
+if (storedKey) {
+    apiKeyInput.value = storedKey;
 }
+
+formEl.addEventListener('submit', async (e) => {
+    e.preventDefault();
+
+    const apiKey = apiKeyInput.value.trim() || window.OPENAI_API_KEY || storedKey || '';
+    if (!apiKey) {
+        resultEl.textContent = 'API キーを入力してください。';
+        return;
+    }
+    localStorage.setItem('OPENAI_API_KEY', apiKey);
+
+    const name = document.getElementById('name').value;
+    const prompt = `${name}さんの今日の運勢を教えてください。`;
+
+    try {
+        const response = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`
+            },
+            body: JSON.stringify({
+                model: 'gpt-4o-mini',
+                messages: [{ role: 'user', content: prompt }]
+            })
+        });
+
+        if (!response.ok) {
+            resultEl.textContent = `API リクエストに失敗しました: ${response.status} ${response.statusText}`;
+            return;
+        }
+
+        const data = await response.json();
+        const result = data.choices?.[0]?.message?.content;
+        resultEl.textContent = result || 'エラーが発生しました';
+    } catch (err) {
+        resultEl.textContent = 'リクエストに失敗しました。';
+    }
+});


### PR DESCRIPTION
## Summary
- add an input field for the OpenAI API key in the fortune demo
- read and store the API key in localStorage instead of editing the script
- document the new workflow in README

## Testing
- `pre-commit` *(fails: command not found)*