### PR TITLE
Add GitHub Actions workflow for Tetris deployment

### DIFF
--- a/.github/workflows/tetris-deploy.yml
+++ b/.github/workflows/tetris-deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy Tetris to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./


### PR DESCRIPTION
## Summary
- create a workflow to publish the Tetris site via GitHub Pages

## Testing
- `git status --short`